### PR TITLE
fix: smooth over system test bumps

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -170,6 +170,31 @@ Running System Tests
 
    $ export GOOGLE_APPLICATION_CREDENTIALS="/Users/<your_username>/path/to/app_credentials.json"
 
+- You'll need to create composite
+  `indexes <https://cloud.google.com/datastore/docs/tools/indexconfig>`__
+  with the ``gcloud`` command line
+  `tool <https://developers.google.com/cloud/sdk/gcloud/>`__::
+
+   # Install the app (App Engine Command Line Interface) component.
+   $ gcloud components install app-engine-python
+
+   # Authenticate the gcloud tool with your account.
+   $ GOOGLE_APPLICATION_CREDENTIALS="path/to/app_credentials.json"
+   $ gcloud auth activate-service-account    > --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+
+   # Create the indexes
+   $ gcloud datastore indexes create tests/system/index.yaml
+
+- You'll also need stored data in your dataset. To populate this data, run::
+
+   $ python tests/system/utils/populate_datastore.py
+
+- If you make a mistake during development (i.e. a failing test that
+  prevents clean-up) you can clear all system test data from your
+  datastore instance via::
+
+   $ python tests/system/utils/clear_datastore.py
+
 
 *************
 Test Coverage

--- a/synth.py
+++ b/synth.py
@@ -82,6 +82,7 @@ num = s.replace(
 
 if num != 1:
     raise Exception("Required replacement not made.")
+
 # ----------------------------------------------------------------------------
 # Add templated files
 # ----------------------------------------------------------------------------
@@ -91,3 +92,39 @@ s.move(templated_files, excludes=["docs/conf.py", "docs/multiprocessing.rst"])
 s.replace("noxfile.py", """["']sphinx['"]""", '''"sphinx<3.0.0"''')
 
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)
+
+# Add documentation about creating indexes and populating data for system
+# tests.
+num = s.replace(
+    "CONTRIBUTING.rst",
+    'app_credentials.json"',
+    """app_credentials.json"
+
+- You'll need to create composite
+  `indexes <https://cloud.google.com/datastore/docs/tools/indexconfig>`__
+  with the ``gcloud`` command line
+  `tool <https://developers.google.com/cloud/sdk/gcloud/>`__::
+
+   # Install the app (App Engine Command Line Interface) component.
+   $ gcloud components install app-engine-python
+
+   # Authenticate the gcloud tool with your account.
+   $ GOOGLE_APPLICATION_CREDENTIALS="path/to/app_credentials.json"
+   $ gcloud auth activate-service-account \
+   > --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+
+   # Create the indexes
+   $ gcloud datastore indexes create tests/system/index.yaml
+
+- You'll also need stored data in your dataset. To populate this data, run::
+
+   $ python tests/system/utils/populate_datastore.py
+
+- If you make a mistake during development (i.e. a failing test that
+  prevents clean-up) you can clear all system test data from your
+  datastore instance via::
+
+   $ python tests/system/utils/clear_datastore.py""")
+
+if num != 1:
+    raise Exception("Required replacement not made.")

--- a/tests/system/utils/populate_datastore.py
+++ b/tests/system/utils/populate_datastore.py
@@ -156,7 +156,7 @@ def add_timestamp_keys(client=None):
         # Get a client that uses the test dataset.
         client = datastore.Client()
 
-    num_batches = 2
+    num_batches = 20
     batch_size = 500
 
     timestamp_micros = set()


### PR DESCRIPTION
Adds back some missing documentation to `CONTRIBUTING.rst` that covers
creating indexes and populating test data for system tests.

Also increases the number of `timestamp_key` entities created by
`populate_datastore.py` to 10000, so that system tests can pass.
