### PR TITLE
fix: use version.py instead of pkg_resources.get_distribution

### DIFF
--- a/google/cloud/datastore/__init__.py
+++ b/google/cloud/datastore/__init__.py
@@ -55,10 +55,7 @@ The main concepts with this API are:
 """
 
 
-from pkg_resources import get_distribution
-
-__version__ = get_distribution("google-cloud-datastore").version
-
+from google.cloud.datastore.version import __version__
 from google.cloud.datastore.batch import Batch
 from google.cloud.datastore.client import Client
 from google.cloud.datastore.entity import Entity

--- a/google/cloud/datastore/client.py
+++ b/google/cloud/datastore/client.py
@@ -21,7 +21,7 @@ from google.auth.credentials import AnonymousCredentials
 from google.cloud._helpers import _LocalStack
 from google.cloud._helpers import _determine_default_project as _base_default_project
 from google.cloud.client import ClientWithProject
-from google.cloud.datastore import __version__
+from google.cloud.datastore.version import __version__
 from google.cloud.datastore import helpers
 from google.cloud.datastore._http import HTTPDatastoreAPI
 from google.cloud.datastore.batch import Batch

--- a/google/cloud/datastore/version.py
+++ b/google/cloud/datastore/version.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "1.15.1"

--- a/google/cloud/datastore_admin_v1/gapic/datastore_admin_client.py
+++ b/google/cloud/datastore_admin_v1/gapic/datastore_admin_client.py
@@ -42,6 +42,8 @@ from google.cloud.datastore_admin_v1.proto import index_pb2
 from google.longrunning import operations_pb2
 from google.protobuf import empty_pb2
 
+# To avoid importing datastore into admin (which would result in a
+# circular dependency), We exec to get the version via a dict.
 version = {}
 with open("../../datastore/version.py") as fp:
     exec(fp.read(), version)

--- a/google/cloud/datastore_admin_v1/gapic/datastore_admin_client.py
+++ b/google/cloud/datastore_admin_v1/gapic/datastore_admin_client.py
@@ -17,6 +17,7 @@
 """Accesses the google.datastore.admin.v1 DatastoreAdmin API."""
 
 import functools
+import os
 import warnings
 
 from google.oauth2 import service_account
@@ -44,9 +45,12 @@ from google.protobuf import empty_pb2
 
 # To avoid importing datastore into admin (which would result in a
 # circular dependency), We exec to get the version via a dict.
+dir_path = os.path.abspath(os.path.dirname(__file__))
+
 version = {}
-with open("../../datastore/version.py") as fp:
+with open(os.path.join(dir_path,"../../datastore/version.py")) as fp:
     exec(fp.read(), version)
+
 _GAPIC_LIBRARY_VERSION = version["__version__"]
 
 

--- a/google/cloud/datastore_admin_v1/gapic/datastore_admin_client.py
+++ b/google/cloud/datastore_admin_v1/gapic/datastore_admin_client.py
@@ -17,7 +17,6 @@
 """Accesses the google.datastore.admin.v1 DatastoreAdmin API."""
 
 import functools
-import pkg_resources
 import warnings
 
 from google.oauth2 import service_account
@@ -43,10 +42,10 @@ from google.cloud.datastore_admin_v1.proto import index_pb2
 from google.longrunning import operations_pb2
 from google.protobuf import empty_pb2
 
-
-_GAPIC_LIBRARY_VERSION = pkg_resources.get_distribution(
-    "google-cloud-datastore",
-).version
+version = {}
+with open("../../datastore/version.py") as fp:
+    exec(fp.read(), version)
+_GAPIC_LIBRARY_VERSION = version["__version__"]
 
 
 class DatastoreAdminClient(object):

--- a/google/cloud/datastore_admin_v1/gapic/datastore_admin_client.py
+++ b/google/cloud/datastore_admin_v1/gapic/datastore_admin_client.py
@@ -46,9 +46,8 @@ from google.protobuf import empty_pb2
 # To avoid importing datastore into admin (which would result in a
 # circular dependency), We exec to get the version via a dict.
 dir_path = os.path.abspath(os.path.dirname(__file__))
-
 version = {}
-with open(os.path.join(dir_path,"../../datastore/version.py")) as fp:
+with open(os.path.join(dir_path, "../../datastore/version.py")) as fp:
     exec(fp.read(), version)
 
 _GAPIC_LIBRARY_VERSION = version["__version__"]

--- a/google/cloud/datastore_v1/gapic/datastore_client.py
+++ b/google/cloud/datastore_v1/gapic/datastore_client.py
@@ -36,11 +36,10 @@ from google.cloud.datastore_v1.proto import datastore_pb2
 from google.cloud.datastore_v1.proto import datastore_pb2_grpc
 from google.cloud.datastore_v1.proto import entity_pb2
 from google.cloud.datastore_v1.proto import query_pb2
+from google.cloud.datastore.version import __version__
 
 
-_GAPIC_LIBRARY_VERSION = pkg_resources.get_distribution(
-    "google-cloud-datastore",
-).version
+_GAPIC_LIBRARY_VERSION = __version__
 
 
 class DatastoreClient(object):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,11 @@ import setuptools
 
 name = "google-cloud-datastore"
 description = "Google Cloud Datastore API client library"
-version = "1.15.1"
+version = {}
+with open("google/cloud/datastore/version.py") as fp:
+    exec(fp.read(), version)
+version = version["__version__"]
+
 # Should be one of:
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'


### PR DESCRIPTION
As part of https://github.com/googleapis/python-api-core/issues/27 and removing reliance on version metadata from pip packaging.

This PR currently alters generated surface.