### PR TITLE
feat: support autoconversion of Entity to Key for purposes of delete & delete_multi

### DIFF
--- a/google/cloud/datastore/client.py
+++ b/google/cloud/datastore/client.py
@@ -673,14 +673,7 @@ class Client(ClientWithProject):
 
         for key in keys:
             if isinstance(key, Entity):
-                # While the interface is technically to take an iterable of keys
-                # if an entity is provided the key can be extracted.
-                message = (
-                    "A list of :class:`google.cloud.datastore.key.Key` is expected. "
-                    + "Extracting Key from "
-                    + ":class:`google.cloud.datastore.entity.Entity`."
-                )
-                warnings.warn(message, UserWarning)
+                # If the key is in fact an Entity, the key can be extracted.
                 key = key.key
             current.delete(key)
 

--- a/google/cloud/datastore/client.py
+++ b/google/cloud/datastore/client.py
@@ -671,6 +671,16 @@ class Client(ClientWithProject):
             current.begin()
 
         for key in keys:
+            if type(key) is Entity:
+                # While the interface is technically to take an iterable of keys
+                # if an entity is provided the key can be extracted.
+                message = (
+                    "A list of :class:`google.cloud.datastore.key.Key` is expected. "
+                    + "Extracting Key from "
+                    + ":class:`google.cloud.datastore.entity.Entity`."
+                )
+                warnings.warn(message, UserWarning)
+                key = key.key
             current.delete(key)
 
         if not in_batch:

--- a/google/cloud/datastore/client.py
+++ b/google/cloud/datastore/client.py
@@ -622,7 +622,8 @@ class Client(ClientWithProject):
            The backend API does not make a distinction between a single key or
            multiple keys in a commit request.
 
-        :type key: :class:`google.cloud.datastore.key.Key`
+        :type key: :class:`google.cloud.datastore.key.Key`, :class:`google.cloud.datastore.entity.Entity`
+
         :param key: The key to be deleted from the datastore.
 
         :type retry: :class:`google.api_core.retry.Retry`
@@ -643,7 +644,7 @@ class Client(ClientWithProject):
     def delete_multi(self, keys, retry=None, timeout=None):
         """Delete keys from the Cloud Datastore.
 
-        :type keys: list of :class:`google.cloud.datastore.key.Key`
+        :type keys: list of :class:`google.cloud.datastore.key.Key`, :class:`google.cloud.datastore.entity.Entity`
         :param keys: The keys to be deleted from the Datastore.
 
         :type retry: :class:`google.api_core.retry.Retry`

--- a/google/cloud/datastore/client.py
+++ b/google/cloud/datastore/client.py
@@ -671,7 +671,7 @@ class Client(ClientWithProject):
             current.begin()
 
         for key in keys:
-            if type(key) is Entity:
+            if isinstance(key, Entity):
                 # While the interface is technically to take an iterable of keys
                 # if an entity is provided the key can be extracted.
                 message = (

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -54,9 +54,7 @@ def clone_client(client):
         )
     else:
         return datastore.Client(
-            project=client.project,
-            namespace=client.namespace,
-            _http=client._http,
+            project=client.project, namespace=client.namespace, _http=client._http,
         )
 
 
@@ -69,9 +67,7 @@ def setUpModule():
     else:
         http = requests.Session()  # Un-authorized.
         Config.CLIENT = datastore.Client(
-            project=emulator_dataset,
-            namespace=test_namespace,
-            _http=http,
+            project=emulator_dataset, namespace=test_namespace, _http=http,
         )
 
 

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -54,7 +54,9 @@ def clone_client(client):
         )
     else:
         return datastore.Client(
-            project=client.project, namespace=client.namespace, _http=client._http,
+            project=client.project,
+            namespace=client.namespace,
+            _http=client._http,
         )
 
 
@@ -67,14 +69,15 @@ def setUpModule():
     else:
         http = requests.Session()  # Un-authorized.
         Config.CLIENT = datastore.Client(
-            project=emulator_dataset, namespace=test_namespace, _http=http,
+            project=emulator_dataset,
+            namespace=test_namespace,
+            _http=http,
         )
 
 
 def tearDownModule():
-    keys = [entity.key for entity in Config.TO_DELETE]
     with Config.CLIENT.transaction():
-        Config.CLIENT.delete_multi(keys)
+        Config.CLIENT.delete_multi(Config.TO_DELETE)
 
 
 class TestDatastore(unittest.TestCase):
@@ -83,8 +86,7 @@ class TestDatastore(unittest.TestCase):
 
     def tearDown(self):
         with Config.CLIENT.transaction():
-            keys = [entity.key for entity in self.case_entities_to_delete]
-            Config.CLIENT.delete_multi(keys)
+            Config.CLIENT.delete_multi(self.case_entities_to_delete)
 
 
 class TestDatastoreAllocateIDs(TestDatastore):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -181,9 +181,7 @@ class TestClient(unittest.TestCase):
         self.assertIsNone(client.current_batch)
         self.assertIsNone(client.current_transaction)
 
-        default.assert_called_once_with(
-            scopes=klass.SCOPE,
-        )
+        default.assert_called_once_with(scopes=klass.SCOPE,)
         _determine_default_project.assert_called_once_with(None)
 
     def test_constructor_w_explicit_inputs(self):


### PR DESCRIPTION
Fixes #122

Can discuss if we should
- have a warning
or
- modify documented type of delete and delete_multi to mention they can take `Entity`


```
❯ python tests/system/test_delete.py
Deleting 20 entities: 5121006972698624, 5150910414061568, 5629847317512192, 5635426882682880, 5644748102565888, 5660593176444928, 5670520389369856, 5680769993277440, 5693029306335232, 5697954694299648, 5701878616686592, 5708050082037760, 5709769612460032, 5744781917421568, 5746397093560320, 5746853299617792, 5754048175144960, 5756417252261888, 5762132310228992, 6251525647106048
/Users/crwilcox/workspace/python-datastore/google/cloud/datastore/client.py:682: UserWarning: A list of :class:`google.cloud.datastore.key.Key` is expected. Extracting Key from :class:`google.cloud.datastore.entity.Entity`.
  warnings.warn(message, UserWarning)
```

