### PR TITLE
fix: make HTTPDatastoreAPI compatible w/ microgen Gapic API

### DIFF
--- a/google/cloud/datastore/_http.py
+++ b/google/cloud/datastore/_http.py
@@ -31,7 +31,37 @@ API_URL_TEMPLATE = "{api_base}/{api_version}/projects" "/{project}:{method}"
 """A template for the URL of a particular API call."""
 
 
-def _request(http, project, method, data, base_url, client_info):
+def _make_retry_timeout_kwargs(retry, timeout):
+    """Helper for methods taking optional retry / timout args."""
+    kwargs = {}
+
+    if retry is not None:
+        kwargs["retry"] = retry
+
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+
+    return kwargs
+
+
+def _make_request_pb(request, request_pb_type):
+    """Helper for converting dicts to request messages."""
+    if not isinstance(request, request_pb_type):
+        request = request_pb_type(**request)
+
+    return request
+
+
+def _request(
+    http,
+    project,
+    method,
+    data,
+    base_url,
+    client_info,
+    retry=None,
+    timeout=None,
+):
     """Make a request over the Http transport to the Cloud Datastore API.
 
     :type http: :class:`requests.Session`
@@ -54,6 +84,12 @@ def _request(http, project, method, data, base_url, client_info):
     :type client_info: :class:`google.api_core.client_info.ClientInfo`
     :param client_info: used to generate user agent.
 
+    :type retry: :class:`google.api_core.retry.Retry`
+    :param retry: (Optional) retry policy for the request
+
+    :type timeout: float or tuple(float, float)
+    :param timeout: (Optional) timeout for the request
+
     :rtype: str
     :returns: The string response content from the API call.
     :raises: :class:`google.cloud.exceptions.GoogleCloudError` if the
@@ -67,7 +103,18 @@ def _request(http, project, method, data, base_url, client_info):
     }
     api_url = build_api_url(project, method, base_url)
 
-    response = http.request(url=api_url, method="POST", headers=headers, data=data)
+    requester = http.request
+
+    if retry is not None:
+        requester = retry(requester)
+
+    if timeout is not None:
+        response = requester(
+            url=api_url, method="POST", headers=headers, data=data, timeout=timeout,
+        )
+    else:
+        response = requester(url=api_url, method="POST", headers=headers, data=data)
+
 
     if response.status_code != 200:
         error_status = status_pb2.Status.FromString(response.content)
@@ -78,7 +125,17 @@ def _request(http, project, method, data, base_url, client_info):
     return response.content
 
 
-def _rpc(http, project, method, base_url, client_info, request_pb, response_pb_cls):
+def _rpc(
+    http,
+    project,
+    method,
+    base_url,
+    client_info,
+    request_pb,
+    response_pb_cls,
+    retry=None,
+    timeout=None,
+):
     """Make a protobuf RPC request.
 
     :type http: :class:`requests.Session`
@@ -105,11 +162,26 @@ def _rpc(http, project, method, base_url, client_info, request_pb, response_pb_c
     :param response_pb_cls: The class used to unmarshall the response
                             protobuf.
 
+    :type retry: :class:`google.api_core.retry.Retry`
+    :param retry: (Optional) retry policy for the request
+
+    :type timeout: float or tuple(float, float)
+    :param timeout: (Optional) timeout for the request
+
     :rtype: :class:`google.protobuf.message.Message`
     :returns: The RPC message parsed from the response.
     """
     req_data = request_pb._pb.SerializeToString()
-    response = _request(http, project, method, req_data, base_url, client_info)
+    kwargs = _make_retry_timeout_kwargs(retry, timeout)
+    response = _request(
+        http,
+        project,
+        method,
+        req_data,
+        base_url,
+        client_info,
+        **kwargs
+    )
     return response_pb_cls.deserialize(response)
 
 
@@ -149,21 +221,23 @@ class HTTPDatastoreAPI(object):
     def __init__(self, client):
         self.client = client
 
-    def lookup(self, request):
+    def lookup(self, request, retry=None, timeout=None):
         """Perform a ``lookup`` request.
 
         :type request: :class:`_datastore_pb2.LookupRequest` or dict
         :param request:
             Parameter bundle for API request.
 
+        :type retry: :class:`google.api_core.retry.Retry`
+        :param retry: (Optional) retry policy for the request
+
+        :type timeout: float or tuple(float, float)
+        :param timeout: (Optional) timeout for the request
+
         :rtype: :class:`.datastore_pb2.LookupResponse`
         :returns: The returned protobuf response object.
         """
-        if not isinstance(request, _datastore_pb2.LookupRequest):
-            request_pb = _datastore_pb2.LookupRequest(**request)
-        else:
-            request_pb = request
-
+        request_pb = _make_request_pb(request, _datastore_pb2.LookupRequest)
         project_id = request_pb.project_id
 
         return _rpc(
@@ -174,23 +248,27 @@ class HTTPDatastoreAPI(object):
             self.client._client_info,
             request_pb,
             _datastore_pb2.LookupResponse,
+            retry=retry,
+            timeout=timeout,
         )
 
-    def run_query(self, request):
+    def run_query(self, request, retry=None, timeout=None):
         """Perform a ``runQuery`` request.
 
         :type request: :class:`_datastore_pb2.BeginTransactionRequest` or dict
         :param request:
             Parameter bundle for API request.
 
+        :type retry: :class:`google.api_core.retry.Retry`
+        :param retry: (Optional) retry policy for the request
+
+        :type timeout: float or tuple(float, float)
+        :param timeout: (Optional) timeout for the request
+
         :rtype: :class:`.datastore_pb2.RunQueryResponse`
         :returns: The returned protobuf response object.
         """
-        if not isinstance(request, _datastore_pb2.RunQueryRequest):
-            request_pb = _datastore_pb2.RunQueryRequest(**request)
-        else:
-            request_pb = request
-
+        request_pb = _make_request_pb(request, _datastore_pb2.RunQueryRequest)
         project_id = request_pb.project_id
 
         return _rpc(
@@ -201,23 +279,27 @@ class HTTPDatastoreAPI(object):
             self.client._client_info,
             request_pb,
             _datastore_pb2.RunQueryResponse,
+            retry=retry,
+            timeout=timeout,
         )
 
-    def begin_transaction(self, request):
+    def begin_transaction(self, request, retry=None, timeout=None):
         """Perform a ``beginTransaction`` request.
 
         :type request: :class:`_datastore_pb2.BeginTransactionRequest` or dict
         :param request:
             Parameter bundle for API request.
 
+        :type retry: :class:`google.api_core.retry.Retry`
+        :param retry: (Optional) retry policy for the request
+
+        :type timeout: float or tuple(float, float)
+        :param timeout: (Optional) timeout for the request
+
         :rtype: :class:`.datastore_pb2.BeginTransactionResponse`
         :returns: The returned protobuf response object.
         """
-        if not isinstance(request, _datastore_pb2.BeginTransactionRequest):
-            request_pb = _datastore_pb2.BeginTransactionRequest(**request)
-        else:
-            request_pb = request
-
+        request_pb = _make_request_pb(request, _datastore_pb2.BeginTransactionRequest)
         project_id = request_pb.project_id
 
         return _rpc(
@@ -228,23 +310,27 @@ class HTTPDatastoreAPI(object):
             self.client._client_info,
             request_pb,
             _datastore_pb2.BeginTransactionResponse,
+            retry=retry,
+            timeout=timeout,
         )
 
-    def commit(self, request):
+    def commit(self, request, retry=None, timeout=None):
         """Perform a ``commit`` request.
 
         :type request: :class:`_datastore_pb2.CommitRequest` or dict
         :param request:
             Parameter bundle for API request.
 
+        :type retry: :class:`google.api_core.retry.Retry`
+        :param retry: (Optional) retry policy for the request
+
+        :type timeout: float or tuple(float, float)
+        :param timeout: (Optional) timeout for the request
+
         :rtype: :class:`.datastore_pb2.CommitResponse`
         :returns: The returned protobuf response object.
         """
-        if not isinstance(request, _datastore_pb2.CommitRequest):
-            request_pb = _datastore_pb2.CommitRequest(**request)
-        else:
-            request_pb = request
-
+        request_pb = _make_request_pb(request, _datastore_pb2.CommitRequest)
         project_id = request_pb.project_id
 
         return _rpc(
@@ -255,23 +341,27 @@ class HTTPDatastoreAPI(object):
             self.client._client_info,
             request_pb,
             _datastore_pb2.CommitResponse,
+            retry=retry,
+            timeout=timeout,
         )
 
-    def rollback(self, request):
+    def rollback(self, request, retry=None, timeout=None):
         """Perform a ``rollback`` request.
 
         :type request: :class:`_datastore_pb2.RollbackRequest` or dict
         :param request:
             Parameter bundle for API request.
 
+        :type retry: :class:`google.api_core.retry.Retry`
+        :param retry: (Optional) retry policy for the request
+
+        :type timeout: float or tuple(float, float)
+        :param timeout: (Optional) timeout for the request
+
         :rtype: :class:`.datastore_pb2.RollbackResponse`
         :returns: The returned protobuf response object.
         """
-        if not isinstance(request, _datastore_pb2.RollbackRequest):
-            request_pb = _datastore_pb2.RollbackRequest(**request)
-        else:
-            request_pb = request
-
+        request_pb = _make_request_pb(request, _datastore_pb2.RollbackRequest)
         project_id = request_pb.project_id
 
         return _rpc(
@@ -282,23 +372,27 @@ class HTTPDatastoreAPI(object):
             self.client._client_info,
             request_pb,
             _datastore_pb2.RollbackResponse,
+            retry=retry,
+            timeout=timeout,
         )
 
-    def allocate_ids(self, request):
+    def allocate_ids(self, request, retry=None, timeout=None):
         """Perform an ``allocateIds`` request.
 
         :type request: :class:`_datastore_pb2.AllocateIdsRequest` or dict
         :param request:
             Parameter bundle for API request.
 
+        :type retry: :class:`google.api_core.retry.Retry`
+        :param retry: (Optional) retry policy for the request
+
+        :type timeout: float or tuple(float, float)
+        :param timeout: (Optional) timeout for the request
+
         :rtype: :class:`.datastore_pb2.AllocateIdsResponse`
         :returns: The returned protobuf response object.
         """
-        if not isinstance(request, _datastore_pb2.AllocateIdsRequest):
-            request_pb = _datastore_pb2.AllocateIdsRequest(**request)
-        else:
-            request_pb = request
-
+        request_pb = _make_request_pb(request, _datastore_pb2.AllocateIdsRequest)
         project_id = request_pb.project_id
 
         return _rpc(
@@ -309,23 +403,27 @@ class HTTPDatastoreAPI(object):
             self.client._client_info,
             request_pb,
             _datastore_pb2.AllocateIdsResponse,
+            retry=retry,
+            timeout=timeout,
         )
 
-    def reserve_ids(self, request):
+    def reserve_ids(self, request, retry=None, timeout=None):
         """Perform an ``reserveIds`` request.
 
         :type request: :class:`_datastore_pb2.ReserveIdsRequest` or dict
         :param request:
             Parameter bundle for API request.
 
+        :type retry: :class:`google.api_core.retry.Retry`
+        :param retry: (Optional) retry policy for the request
+
+        :type timeout: float or tuple(float, float)
+        :param timeout: (Optional) timeout for the request
+
         :rtype: :class:`.datastore_pb2.ReserveIdsResponse`
         :returns: The returned protobuf response object.
         """
-        if not isinstance(request, _datastore_pb2.ReserveIdsRequest):
-            request_pb = _datastore_pb2.ReserveIdsRequest(**request)
-        else:
-            request_pb = request
-
+        request_pb = _make_request_pb(request, _datastore_pb2.ReserveIdsRequest)
         project_id = request_pb.project_id
 
         return _rpc(
@@ -336,4 +434,6 @@ class HTTPDatastoreAPI(object):
             self.client._client_info,
             request_pb,
             _datastore_pb2.ReserveIdsResponse,
+            retry=retry,
+            timeout=timeout,
         )

--- a/google/cloud/datastore/_http.py
+++ b/google/cloud/datastore/_http.py
@@ -149,27 +149,23 @@ class HTTPDatastoreAPI(object):
     def __init__(self, client):
         self.client = client
 
-    def lookup(self, project_id, keys, read_options=None):
+    def lookup(self, request):
         """Perform a ``lookup`` request.
 
-        :type project_id: str
-        :param project_id: The project to connect to. This is
-                           usually your project name in the cloud console.
-
-        :type keys: List[.entity_pb2.Key]
-        :param keys: The keys to retrieve from the datastore.
-
-        :type read_options: :class:`.datastore_pb2.ReadOptions`
-        :param read_options: (Optional) The options for this lookup. Contains
-                             either the transaction for the read or
-                             ``STRONG`` or ``EVENTUAL`` read consistency.
+        :type request: :class:`_datastore_pb2.LookupRequest` or dict
+        :param request:
+            Parameter bundle for API request.
 
         :rtype: :class:`.datastore_pb2.LookupResponse`
         :returns: The returned protobuf response object.
         """
-        request_pb = _datastore_pb2.LookupRequest(
-            project_id=project_id, read_options=read_options, keys=keys
-        )
+        if not isinstance(request, _datastore_pb2.LookupRequest):
+            request_pb = _datastore_pb2.LookupRequest(**request)
+        else:
+            request_pb = request
+
+        project_id = request_pb.project_id
+
         return _rpc(
             self.client._http,
             project_id,

--- a/google/cloud/datastore/_http.py
+++ b/google/cloud/datastore/_http.py
@@ -342,3 +342,30 @@ class HTTPDatastoreAPI(object):
             request_pb,
             _datastore_pb2.AllocateIdsResponse,
         )
+
+    def reserve_ids(self, request):
+        """Perform an ``reserveIds`` request.
+
+        :type request: :class:`_datastore_pb2.ReserveIdsRequest` or dict
+        :param request:
+            Parameter bundle for API request.
+
+        :rtype: :class:`.datastore_pb2.ReserveIdsResponse`
+        :returns: The returned protobuf response object.
+        """
+        if not isinstance(request, _datastore_pb2.ReserveIdsRequest):
+            request_pb = _datastore_pb2.ReserveIdsRequest(**request)
+        else:
+            request_pb = request
+
+        project_id = request_pb.project_id
+
+        return _rpc(
+            self.client._http,
+            project_id,
+            "reserveIds",
+            self.client._base_url,
+            self.client._client_info,
+            request_pb,
+            _datastore_pb2.ReserveIdsResponse,
+        )

--- a/google/cloud/datastore/_http.py
+++ b/google/cloud/datastore/_http.py
@@ -250,35 +250,23 @@ class HTTPDatastoreAPI(object):
             _datastore_pb2.BeginTransactionResponse,
         )
 
-    def commit(self, project_id, mode, mutations, transaction=None):
+    def commit(self, request):
         """Perform a ``commit`` request.
 
-        :type project_id: str
-        :param project_id: The project to connect to. This is
-                           usually your project name in the cloud console.
-
-        :type mode: :class:`.gapic.datastore.v1.enums.CommitRequest.Mode`
-        :param mode: The type of commit to perform. Expected to be one of
-                     ``TRANSACTIONAL`` or ``NON_TRANSACTIONAL``.
-
-        :type mutations: list
-        :param mutations: List of :class:`.datastore_pb2.Mutation`, the
-                          mutations to perform.
-
-        :type transaction: bytes
-        :param transaction: (Optional) The transaction ID returned from
-                            :meth:`begin_transaction`.  Non-transactional
-                            commits must pass :data:`None`.
+        :type request: :class:`_datastore_pb2.CommitRequest` or dict
+        :param request:
+            Parameter bundle for API request.
 
         :rtype: :class:`.datastore_pb2.CommitResponse`
         :returns: The returned protobuf response object.
         """
-        request_pb = _datastore_pb2.CommitRequest(
-            project_id=project_id,
-            mode=mode,
-            transaction=transaction,
-            mutations=mutations,
-        )
+        if not isinstance(request, _datastore_pb2.CommitRequest):
+            request_pb = _datastore_pb2.CommitRequest(**request)
+        else:
+            request_pb = request
+
+        project_id = request_pb.project_id
+
         return _rpc(
             self.client._http,
             project_id,

--- a/google/cloud/datastore/_http.py
+++ b/google/cloud/datastore/_http.py
@@ -180,42 +180,23 @@ class HTTPDatastoreAPI(object):
             _datastore_pb2.LookupResponse,
         )
 
-    def run_query(
-        self, project_id, partition_id, read_options=None, query=None, gql_query=None
-    ):
+    def run_query(self, request):
         """Perform a ``runQuery`` request.
 
-        :type project_id: str
-        :param project_id: The project to connect to. This is
-                           usually your project name in the cloud console.
-
-        :type partition_id: :class:`.entity_pb2.PartitionId`
-        :param partition_id: Partition ID corresponding to an optional
-                             namespace and project ID.
-
-        :type read_options: :class:`.datastore_pb2.ReadOptions`
-        :param read_options: (Optional) The options for this query. Contains
-                             either the transaction for the read or
-                             ``STRONG`` or ``EVENTUAL`` read consistency.
-
-        :type query: :class:`.query_pb2.Query`
-        :param query: (Optional) The query protobuf to run. At most one of
-                      ``query`` and ``gql_query`` can be specified.
-
-        :type gql_query: :class:`.query_pb2.GqlQuery`
-        :param gql_query: (Optional) The GQL query to run. At most one of
-                          ``query`` and ``gql_query`` can be specified.
+        :type request: :class:`_datastore_pb2.BeginTransactionRequest` or dict
+        :param request:
+            Parameter bundle for API request.
 
         :rtype: :class:`.datastore_pb2.RunQueryResponse`
         :returns: The returned protobuf response object.
         """
-        request_pb = _datastore_pb2.RunQueryRequest(
-            project_id=project_id,
-            partition_id=partition_id,
-            read_options=read_options,
-            query=query,
-            gql_query=gql_query,
-        )
+        if not isinstance(request, _datastore_pb2.RunQueryRequest):
+            request_pb = _datastore_pb2.RunQueryRequest(**request)
+        else:
+            request_pb = request
+
+        project_id = request_pb.project_id
+
         return _rpc(
             self.client._http,
             project_id,

--- a/google/cloud/datastore/_http.py
+++ b/google/cloud/datastore/_http.py
@@ -316,20 +316,23 @@ class HTTPDatastoreAPI(object):
             _datastore_pb2.RollbackResponse,
         )
 
-    def allocate_ids(self, project_id, keys):
+    def allocate_ids(self, request):
         """Perform an ``allocateIds`` request.
 
-        :type project_id: str
-        :param project_id: The project to connect to. This is
-                           usually your project name in the cloud console.
-
-        :type keys: List[.entity_pb2.Key]
-        :param keys: The keys for which the backend should allocate IDs.
+        :type request: :class:`_datastore_pb2.AllocateIdsRequest` or dict
+        :param request:
+            Parameter bundle for API request.
 
         :rtype: :class:`.datastore_pb2.AllocateIdsResponse`
         :returns: The returned protobuf response object.
         """
-        request_pb = _datastore_pb2.AllocateIdsRequest(keys=keys)
+        if not isinstance(request, _datastore_pb2.AllocateIdsRequest):
+            request_pb = _datastore_pb2.AllocateIdsRequest(**request)
+        else:
+            request_pb = request
+
+        project_id = request_pb.project_id
+
         return _rpc(
             self.client._http,
             project_id,

--- a/google/cloud/datastore/_http.py
+++ b/google/cloud/datastore/_http.py
@@ -289,23 +289,23 @@ class HTTPDatastoreAPI(object):
             _datastore_pb2.CommitResponse,
         )
 
-    def rollback(self, project_id, transaction):
+    def rollback(self, request):
         """Perform a ``rollback`` request.
 
-        :type project_id: str
-        :param project_id: The project to connect to. This is
-                           usually your project name in the cloud console.
-
-        :type transaction: bytes
-        :param transaction: The transaction ID to rollback.
+        :type request: :class:`_datastore_pb2.RollbackRequest` or dict
+        :param request:
+            Parameter bundle for API request.
 
         :rtype: :class:`.datastore_pb2.RollbackResponse`
         :returns: The returned protobuf response object.
         """
-        request_pb = _datastore_pb2.RollbackRequest(
-            project_id=project_id, transaction=transaction
-        )
-        # Response is empty (i.e. no fields) but we return it anyway.
+        if not isinstance(request, _datastore_pb2.RollbackRequest):
+            request_pb = _datastore_pb2.RollbackRequest(**request)
+        else:
+            request_pb = request
+
+        project_id = request_pb.project_id
+
         return _rpc(
             self.client._http,
             project_id,

--- a/google/cloud/datastore/_http.py
+++ b/google/cloud/datastore/_http.py
@@ -53,14 +53,7 @@ def _make_request_pb(request, request_pb_type):
 
 
 def _request(
-    http,
-    project,
-    method,
-    data,
-    base_url,
-    client_info,
-    retry=None,
-    timeout=None,
+    http, project, method, data, base_url, client_info, retry=None, timeout=None,
 ):
     """Make a request over the Http transport to the Cloud Datastore API.
 
@@ -114,7 +107,6 @@ def _request(
         )
     else:
         response = requester(url=api_url, method="POST", headers=headers, data=data)
-
 
     if response.status_code != 200:
         error_status = status_pb2.Status.FromString(response.content)
@@ -174,13 +166,7 @@ def _rpc(
     req_data = request_pb._pb.SerializeToString()
     kwargs = _make_retry_timeout_kwargs(retry, timeout)
     response = _request(
-        http,
-        project,
-        method,
-        req_data,
-        base_url,
-        client_info,
-        **kwargs
+        http, project, method, req_data, base_url, client_info, **kwargs
     )
     return response_pb_cls.deserialize(response)
 

--- a/google/cloud/datastore/_http.py
+++ b/google/cloud/datastore/_http.py
@@ -226,20 +226,23 @@ class HTTPDatastoreAPI(object):
             _datastore_pb2.RunQueryResponse,
         )
 
-    def begin_transaction(self, project_id, transaction_options=None):
+    def begin_transaction(self, request):
         """Perform a ``beginTransaction`` request.
 
-        :type project_id: str
-        :param project_id: The project to connect to. This is
-                           usually your project name in the cloud console.
-
-        :type transaction_options: ~.datastore_v1.types.TransactionOptions
-        :param transaction_options: (Optional) Options for a new transaction.
+        :type request: :class:`_datastore_pb2.BeginTransactionRequest` or dict
+        :param request:
+            Parameter bundle for API request.
 
         :rtype: :class:`.datastore_pb2.BeginTransactionResponse`
         :returns: The returned protobuf response object.
         """
-        request_pb = _datastore_pb2.BeginTransactionRequest()
+        if not isinstance(request, _datastore_pb2.BeginTransactionRequest):
+            request_pb = _datastore_pb2.BeginTransactionRequest(**request)
+        else:
+            request_pb = request
+
+        project_id = request_pb.project_id
+
         return _rpc(
             self.client._http,
             project_id,

--- a/noxfile.py
+++ b/noxfile.py
@@ -98,7 +98,8 @@ def unit(session):
 
 
 @nox.session(python=SYSTEM_TEST_PYTHON_VERSIONS)
-def system(session):
+@nox.parametrize("disable_grpc", [False, True])
+def system(session, disable_grpc):
     """Run the system test suite."""
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
@@ -126,11 +127,17 @@ def system(session):
     )
     session.install("-e", ".")
 
+    env = {}
+    if disable_grpc:
+        env["GOOGLE_CLOUD_DISABLE_GRPC"] = "True"
+
     # Run py.test against the system tests.
     if system_test_exists:
-        session.run("py.test", "--quiet", system_test_path, *session.posargs)
+        session.run("py.test", "--quiet", system_test_path, env=env, *session.posargs)
     if system_test_folder_exists:
-        session.run("py.test", "--quiet", system_test_folder_path, *session.posargs)
+        session.run(
+            "py.test", "--quiet", system_test_folder_path, env=env, *session.posargs
+        )
 
 
 @nox.session(python=DEFAULT_PYTHON_VERSION)

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -487,7 +487,9 @@ class TestHTTPDatastoreAPI(unittest.TestCase):
 
         # Make request.
         ds_api = self._make_one(client)
-        response = ds_api.rollback(project, transaction)
+        request={"project_id": project, "transaction": transaction}
+
+        response = ds_api.rollback(request=request)
 
         # Check the result and verify the callers.
         self.assertEqual(response, rsp_pb._pb)
@@ -525,7 +527,7 @@ class TestHTTPDatastoreAPI(unittest.TestCase):
 
         request={"project_id": project, "keys": before_key_pbs}
 
-        response = ds_api.allocate_ids(request)
+        response = ds_api.allocate_ids(request=request)
 
         self.assertEqual(response, rsp_pb._pb)
         self.assertEqual(list(response.keys), [i._pb for i in after_key_pbs])
@@ -567,7 +569,7 @@ class TestHTTPDatastoreAPI(unittest.TestCase):
 
         request={"project_id": project, "keys": before_key_pbs}
 
-        response = ds_api.reserve_ids(request)
+        response = ds_api.reserve_ids(request=request)
 
         self.assertEqual(response, rsp_pb._pb)
 

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -358,12 +358,7 @@ class TestHTTPDatastoreAPI(unittest.TestCase):
         self._lookup_single_helper(empty=False, timeout=timeout)
 
     def _lookup_multiple_helper(
-        self,
-        found=0,
-        missing=0,
-        deferred=0,
-        retry=None,
-        timeout=None,
+        self, found=0, missing=0, deferred=0, retry=None, timeout=None,
     ):
         from google.cloud.datastore_v1.types import datastore as datastore_pb2
         from google.cloud.datastore_v1.types import entity as entity_pb2
@@ -420,9 +415,7 @@ class TestHTTPDatastoreAPI(unittest.TestCase):
 
         self.assertEqual(response, rsp_pb._pb)
 
-        self.assertEqual(
-            [found.entity.key for found in response.found], found_keys
-        )
+        self.assertEqual([found.entity.key for found in response.found], found_keys)
         self.assertEqual(
             [missing.entity.key for missing in response.missing], missing_keys
         )
@@ -707,7 +700,7 @@ class TestHTTPDatastoreAPI(unittest.TestCase):
 
         # Make request.
         ds_api = self._make_one(client)
-        request={"project_id": project, "transaction": transaction}
+        request = {"project_id": project, "transaction": transaction}
         kwargs = _make_retry_timeout_kwargs(retry, timeout, http)
 
         response = ds_api.rollback(request=request, **kwargs)
@@ -717,11 +710,7 @@ class TestHTTPDatastoreAPI(unittest.TestCase):
 
         uri = _build_expected_url(client._base_url, project, "rollback")
         request = _verify_protobuf_call(
-            http,
-            uri,
-            datastore_pb2.RollbackRequest(),
-            retry=retry,
-            timeout=timeout,
+            http, uri, datastore_pb2.RollbackRequest(), retry=retry, timeout=timeout,
         )
         self.assertEqual(request.transaction, transaction)
 
@@ -763,7 +752,7 @@ class TestHTTPDatastoreAPI(unittest.TestCase):
         )
         ds_api = self._make_one(client)
 
-        request={"project_id": project, "keys": before_key_pbs}
+        request = {"project_id": project, "keys": before_key_pbs}
         kwargs = _make_retry_timeout_kwargs(retry, timeout, http)
 
         response = ds_api.allocate_ids(request=request, **kwargs)
@@ -773,11 +762,7 @@ class TestHTTPDatastoreAPI(unittest.TestCase):
 
         uri = _build_expected_url(client._base_url, project, "allocateIds")
         request = _verify_protobuf_call(
-            http,
-            uri,
-            datastore_pb2.AllocateIdsRequest(),
-            retry=retry,
-            timeout=timeout,
+            http, uri, datastore_pb2.AllocateIdsRequest(), retry=retry, timeout=timeout,
         )
         self.assertEqual(len(request.keys), len(before_key_pbs))
         for key_before, key_after in zip(before_key_pbs, request.keys):
@@ -820,7 +805,7 @@ class TestHTTPDatastoreAPI(unittest.TestCase):
         )
         ds_api = self._make_one(client)
 
-        request={"project_id": project, "keys": before_key_pbs}
+        request = {"project_id": project, "keys": before_key_pbs}
         kwargs = _make_retry_timeout_kwargs(retry, timeout, http)
 
         response = ds_api.reserve_ids(request=request, **kwargs)
@@ -829,11 +814,7 @@ class TestHTTPDatastoreAPI(unittest.TestCase):
 
         uri = _build_expected_url(client._base_url, project, "reserveIds")
         request = _verify_protobuf_call(
-            http,
-            uri,
-            datastore_pb2.AllocateIdsRequest(),
-            retry=retry,
-            timeout=timeout,
+            http, uri, datastore_pb2.AllocateIdsRequest(), retry=retry, timeout=timeout,
         )
         self.assertEqual(len(request.keys), len(before_key_pbs))
         for key_before, key_after in zip(before_key_pbs, request.keys):
@@ -923,6 +904,7 @@ def _verify_protobuf_call(http, expected_url, pb, retry=None, timeout=None):
     data = http.request.mock_calls[0][2]["data"]
     pb._pb.ParseFromString(data)
     return pb
+
 
 def _make_retry_timeout_kwargs(retry, timeout, http=None):
     kwargs = {}

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -185,8 +185,13 @@ class TestHTTPDatastoreAPI(unittest.TestCase):
             spec=["_http", "_base_url", "_client_info"],
         )
         ds_api = self._make_one(client)
+        request = {
+            "project_id": project,
+            "keys": [key_pb],
+            "read_options": read_options,
+        }
 
-        response = ds_api.lookup(project, [key_pb], read_options=read_options)
+        response = ds_api.lookup(request=request)
 
         self.assertEqual(response, rsp_pb._pb)
 
@@ -264,8 +269,13 @@ class TestHTTPDatastoreAPI(unittest.TestCase):
             spec=["_http", "_base_url", "_client_info"],
         )
         ds_api = self._make_one(client)
+        request = {
+            "project_id": project,
+            "keys": keys,
+            "read_options": read_options,
+        }
 
-        response = ds_api.lookup(project, keys, read_options=read_options)
+        response = ds_api.lookup(request=request)
 
         self.assertEqual(response, rsp_pb._pb)
 

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -347,8 +347,14 @@ class TestHTTPDatastoreAPI(unittest.TestCase):
             spec=["_http", "_base_url", "_client_info"],
         )
         ds_api = self._make_one(client)
+        request = {
+            "project_id": project,
+            "partition_id": partition_id,
+            "read_options": read_options,
+            "query": query_pb,
+        }
 
-        response = ds_api.run_query(project, partition_id, read_options, query=query_pb)
+        response = ds_api.run_query(request=request)
 
         self.assertEqual(response, rsp_pb._pb)
 

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -523,7 +523,9 @@ class TestHTTPDatastoreAPI(unittest.TestCase):
         )
         ds_api = self._make_one(client)
 
-        response = ds_api.allocate_ids(project, before_key_pbs)
+        request={"project_id": project, "keys": before_key_pbs}
+
+        response = ds_api.allocate_ids(request)
 
         self.assertEqual(response, rsp_pb._pb)
         self.assertEqual(list(response.keys), [i._pb for i in after_key_pbs])

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -437,14 +437,15 @@ class TestHTTPDatastoreAPI(unittest.TestCase):
         rq_class = datastore_pb2.CommitRequest
         ds_api = self._make_one(client)
 
-        kwargs = {}
-        if transaction is not None:
-            kwargs["transaction"] = transaction
-            mode = rq_class.Mode.TRANSACTIONAL
-        else:
-            mode = rq_class.Mode.NON_TRANSACTIONAL
+        request = {"project_id": project, "mutations": [mutation]}
 
-        result = ds_api.commit(project, mode, [mutation], **kwargs)
+        if transaction is not None:
+            request["transaction"] = transaction
+            mode = request["mode"] = rq_class.Mode.TRANSACTIONAL
+        else:
+            mode = request["mode"] = rq_class.Mode.NON_TRANSACTIONAL
+
+        result = ds_api.commit(request=request)
 
         self.assertEqual(result, rsp_pb._pb)
 


### PR DESCRIPTION
- Shift all API-invoking methods of `HTTPDatastoreAPI` to use `request` argument, rather than unpacked args.
- Add `retry` and `timeout` support to all API-invoking methods of `HTTPDatastoreAPI`.
- Add system test session which exercises `HTTPDatastoreAPI` (running with `GOOGLE_DISABLE_RPC` envvar set).

Closes #124.
Closes #132.
Closes #133.
Closes #134.
