### PR TITLE
chore: add yoshi-python to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 
 # The firestore-dpe team is the default owner for anything not
 # explicitly taken by someone else.
-*                               @googleapis/firestore-dpe
+*                               @googleapis/firestore-dpe @googleapis/yoshi-python


### PR DESCRIPTION
Per discussion in today's Python libraries call.