### PR TITLE
perf: further avoid using proto-plus wrapper when unmarshalling entities

### DIFF
--- a/google/cloud/datastore/helpers.py
+++ b/google/cloud/datastore/helpers.py
@@ -95,19 +95,6 @@ def _new_value_pb(entity_pb, name):
     return properties.get_or_create(name)
 
 
-def _property_tuples(entity_pb):
-    """Iterator of name, ``Value`` tuples from entity properties.
-
-    :type entity_pb: :class:`.entity_pb2.Entity`
-    :param entity_pb: An entity protobuf to add a new property to.
-
-    :rtype: :class:`generator`
-    :returns: An iterator that yields tuples of a name and ``Value``
-              corresponding to properties on the entity.
-    """
-    return iter(entity_pb.properties.items())
-
-
 def entity_from_protobuf(pb):
     """Factory method for creating an entity based on a protobuf.
 
@@ -134,7 +121,7 @@ def entity_from_protobuf(pb):
     entity_meanings = {}
     exclude_from_indexes = []
 
-    for prop_name, value_pb in _property_tuples(proto_pb._pb):
+    for prop_name, value_pb in pb.properties.items():
         value = _get_value_from_value_pb(value_pb)
         entity_props[prop_name] = value
 

--- a/google/cloud/datastore/helpers.py
+++ b/google/cloud/datastore/helpers.py
@@ -107,15 +107,12 @@ def entity_from_protobuf(pb):
     :rtype: :class:`google.cloud.datastore.entity.Entity`
     :returns: The entity derived from the protobuf.
     """
-    if not isinstance(pb, entity_pb2.Entity):
-        proto_pb = entity_pb2.Entity.wrap(pb)
-    else:
-        proto_pb = pb
+    if isinstance(pb, entity_pb2.Entity):
         pb = pb._pb
 
     key = None
-    if "key" in proto_pb:  # Message field (Key)
-        key = key_from_protobuf(proto_pb.key)
+    if pb.HasField("key"):  # Message field (Key)
+        key = key_from_protobuf(pb.key)
 
     entity_props = {}
     entity_meanings = {}

--- a/google/cloud/datastore/helpers.py
+++ b/google/cloud/datastore/helpers.py
@@ -89,13 +89,9 @@ def _new_value_pb(entity_pb, name):
     :rtype: :class:`.entity_pb2.Value`
     :returns: The new ``Value`` protobuf that was added to the entity.
     """
-    properties = entity_pb.properties
-    try:
-        properties = properties._pb
-    except AttributeError:
-        # TODO(microgenerator): shouldn't need this. the issue is that
-        # we have wrapped and non-wrapped protos coming here.
-        pass
+    # TODO(microgenerator): shouldn't need this. the issue is that
+    # we have wrapped and non-wrapped protos coming here.
+    properties = getattr(entity_pb.properties, "_pb", entity_pb.properties)
     return properties.get_or_create(name)
 
 

--- a/google/cloud/datastore/helpers.py
+++ b/google/cloud/datastore/helpers.py
@@ -34,8 +34,8 @@ from google.cloud.datastore.key import Key
 def _get_meaning(value_pb, is_list=False):
     """Get the meaning from a protobuf value.
 
-    :type value_pb: :class:`.entity_pb2.Value`
-    :param value_pb: The protobuf value to be checked for an
+    :type value_pb: :class:`.entity_pb2.Value._pb`
+    :param value_pb: The *raw* protobuf value to be checked for an
                      associated meaning.
 
     :type is_list: bool
@@ -49,9 +49,6 @@ def _get_meaning(value_pb, is_list=False):
               list meanings agree, it just condenses them.
     """
     if is_list:
-
-        # Use 'raw' protobuf message if possible
-        value_pb = getattr(value_pb, "_pb", value_pb)
 
         values = value_pb.array_value.values
 

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -118,8 +118,6 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(batch._partial_key_entities, [entity])
 
     def test_put_entity_w_completed_key(self):
-        from google.cloud.datastore.helpers import _property_tuples
-
         project = "PROJECT"
         properties = {"foo": "bar", "baz": "qux", "spam": [1, 2, 3], "frotz": []}
         client = _Client(project)
@@ -134,7 +132,7 @@ class TestBatch(unittest.TestCase):
         mutated_entity = _mutated_pb(self, batch.mutations, "upsert")
         self.assertEqual(mutated_entity.key, key._key)
 
-        prop_dict = dict(_property_tuples(mutated_entity))
+        prop_dict = dict(mutated_entity.properties.items())
         self.assertEqual(len(prop_dict), 4)
         self.assertFalse(prop_dict["foo"].exclude_from_indexes)
         self.assertTrue(prop_dict["baz"].exclude_from_indexes)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -802,7 +802,6 @@ class TestClient(unittest.TestCase):
 
     def test_put_multi_no_batch_w_partial_key_w_retry_w_timeout(self):
         from google.cloud.datastore_v1.types import datastore as datastore_pb2
-        from google.cloud.datastore.helpers import _property_tuples
 
         entity = _Entity(foo=u"bar")
         key = entity.key = _Key(_Key.kind, None)
@@ -838,15 +837,13 @@ class TestClient(unittest.TestCase):
         mutated_entity = _mutated_pb(self, mutations, "insert")
         self.assertEqual(mutated_entity.key, key.to_protobuf())
 
-        prop_list = list(_property_tuples(mutated_entity))
+        prop_list = list(mutated_entity.properties.items())
         self.assertTrue(len(prop_list), 1)
         name, value_pb = prop_list[0]
         self.assertEqual(name, "foo")
         self.assertEqual(value_pb.string_value, u"bar")
 
     def test_put_multi_existing_batch_w_completed_key(self):
-        from google.cloud.datastore.helpers import _property_tuples
-
         creds = _make_credentials()
         client = self._make_one(credentials=creds)
         entity = _Entity(foo=u"bar")
@@ -859,7 +856,7 @@ class TestClient(unittest.TestCase):
         mutated_entity = _mutated_pb(self, CURR_BATCH.mutations, "upsert")
         self.assertEqual(mutated_entity.key, key.to_protobuf())
 
-        prop_list = list(_property_tuples(mutated_entity))
+        prop_list = list(mutated_entity.properties.items())
         self.assertTrue(len(prop_list), 1)
         name, value_pb = prop_list[0]
         self.assertEqual(name, "foo")

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -644,12 +644,12 @@ class Test__get_value_from_value_pb(unittest.TestCase):
 
         return _get_value_from_value_pb(pb)
 
-    def _makePB(self, attr_name, value):
+    def _makePB(self, attr_name, attr_value):
         from google.cloud.datastore_v1.types import entity as entity_pb2
 
-        pb = entity_pb2.Value()
-        setattr(pb, attr_name, value)
-        return pb
+        value = entity_pb2.Value()
+        setattr(value._pb, attr_name, attr_value)
+        return value
 
     def test_datetime(self):
         import calendar
@@ -659,67 +659,67 @@ class Test__get_value_from_value_pb(unittest.TestCase):
 
         micros = 4375
         utc = datetime.datetime(2014, 9, 16, 10, 19, 32, micros, UTC)
-        pb = entity_pb2.Value()
-        pb._pb.timestamp_value.seconds = calendar.timegm(utc.timetuple())
-        pb._pb.timestamp_value.nanos = 1000 * micros
-        self.assertEqual(self._call_fut(pb), utc)
+        value = entity_pb2.Value()
+        value._pb.timestamp_value.seconds = calendar.timegm(utc.timetuple())
+        value._pb.timestamp_value.nanos = 1000 * micros
+        self.assertEqual(self._call_fut(value._pb), utc)
 
     def test_key(self):
         from google.cloud.datastore_v1.types import entity as entity_pb2
         from google.cloud.datastore.key import Key
 
-        pb = entity_pb2.Value()
+        value = entity_pb2.Value()
         expected = Key("KIND", 1234, project="PROJECT").to_protobuf()
-        pb.key_value._pb.CopyFrom(expected._pb)
-        found = self._call_fut(pb)
+        value.key_value._pb.CopyFrom(expected._pb)
+        found = self._call_fut(value._pb)
         self.assertEqual(found.to_protobuf(), expected)
 
     def test_bool(self):
-        pb = self._makePB("boolean_value", False)
-        self.assertEqual(self._call_fut(pb), False)
+        value = self._makePB("boolean_value", False)
+        self.assertEqual(self._call_fut(value._pb), False)
 
     def test_float(self):
-        pb = self._makePB("double_value", 3.1415926)
-        self.assertEqual(self._call_fut(pb), 3.1415926)
+        value = self._makePB("double_value", 3.1415926)
+        self.assertEqual(self._call_fut(value._pb), 3.1415926)
 
     def test_int(self):
-        pb = self._makePB("integer_value", 42)
-        self.assertEqual(self._call_fut(pb), 42)
+        value = self._makePB("integer_value", 42)
+        self.assertEqual(self._call_fut(value._pb), 42)
 
     def test_bytes(self):
-        pb = self._makePB("blob_value", b"str")
-        self.assertEqual(self._call_fut(pb), b"str")
+        value = self._makePB("blob_value", b"str")
+        self.assertEqual(self._call_fut(value._pb), b"str")
 
     def test_unicode(self):
-        pb = self._makePB("string_value", u"str")
-        self.assertEqual(self._call_fut(pb), u"str")
+        value = self._makePB("string_value", u"str")
+        self.assertEqual(self._call_fut(value._pb), u"str")
 
     def test_entity(self):
         from google.cloud.datastore_v1.types import entity as entity_pb2
         from google.cloud.datastore.entity import Entity
         from google.cloud.datastore.helpers import _new_value_pb
 
-        pb = entity_pb2.Value()
-        entity_pb = pb.entity_value
+        value = entity_pb2.Value()
+        entity_pb = value.entity_value
         entity_pb._pb.key.path.add(kind="KIND")
         entity_pb.key.partition_id.project_id = "PROJECT"
 
         value_pb = _new_value_pb(entity_pb, "foo")
         value_pb.string_value = "Foo"
-        entity = self._call_fut(pb)
+        entity = self._call_fut(value._pb)
         self.assertIsInstance(entity, Entity)
         self.assertEqual(entity["foo"], "Foo")
 
     def test_array(self):
         from google.cloud.datastore_v1.types import entity as entity_pb2
 
-        pb = entity_pb2.Value()
-        array_pb = pb.array_value.values
+        value = entity_pb2.Value()
+        array_pb = value.array_value.values
         item_pb = array_pb._pb.add()
         item_pb.string_value = "Foo"
         item_pb = array_pb._pb.add()
         item_pb.string_value = "Bar"
-        items = self._call_fut(pb)
+        items = self._call_fut(value._pb)
         self.assertEqual(items, ["Foo", "Bar"])
 
     def test_geo_point(self):
@@ -730,8 +730,8 @@ class Test__get_value_from_value_pb(unittest.TestCase):
         lat = -3.14
         lng = 13.37
         geo_pt_pb = latlng_pb2.LatLng(latitude=lat, longitude=lng)
-        pb = entity_pb2.Value(geo_point_value=geo_pt_pb)
-        result = self._call_fut(pb)
+        value = entity_pb2.Value(geo_point_value=geo_pt_pb)
+        result = self._call_fut(value._pb)
         self.assertIsInstance(result, GeoPoint)
         self.assertEqual(result.latitude, lat)
         self.assertEqual(result.longitude, lng)
@@ -740,16 +740,16 @@ class Test__get_value_from_value_pb(unittest.TestCase):
         from google.protobuf import struct_pb2
         from google.cloud.datastore_v1.types import entity as entity_pb2
 
-        pb = entity_pb2.Value(null_value=struct_pb2.NULL_VALUE)
-        result = self._call_fut(pb)
+        value = entity_pb2.Value(null_value=struct_pb2.NULL_VALUE)
+        result = self._call_fut(value._pb)
         self.assertIsNone(result)
 
     def test_unknown(self):
         from google.cloud.datastore_v1.types import entity as entity_pb2
 
-        pb = entity_pb2.Value()
+        value = entity_pb2.Value()
         with self.assertRaises(ValueError):
-            self._call_fut(pb)
+            self._call_fut(value._pb)
 
 
 class Test_set_protobuf_value(unittest.TestCase):

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -15,6 +15,7 @@
 import unittest
 
 import mock
+import pytest
 
 
 class TestQuery(unittest.TestCase):
@@ -527,6 +528,7 @@ class TestIterator(unittest.TestCase):
         self.assertIsNone(iterator.next_page_token)
         self.assertFalse(iterator._more_results)
 
+    @pytest.mark.filterwarnings("ignore")
     def test__process_query_results_bad_enum(self):
         iterator = self._make_one(None, None)
         more_results_enum = 999


### PR DESCRIPTION
Follow-on to @craiglabenz's work in PR #155. These tweaks combine to get performance on my [comparison with 1.5.3 script](https://gist.github.com/tseaver/4cf9a78a5dfbc492ef20e80fffdd2498) to within a few percentage points of the 1.5.3 implementation.

```bash
$ /tmp/datastore-1.15.3/bin/python /tmp/compare_perf_issue_1_15_3.py 
Time: 0.9033858776092529
$ /tmp/datastore-HEAD/bin/python /tmp/compare_perf_issue_1_15_3.py 
Time: 0.9162840843200684
```

Closes #150.
