### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,13 +1,13 @@
 {
-  "name": "datastore",
-  "name_pretty": "Google Cloud Datastore",
-  "product_documentation": "https://cloud.google.com/datastore",
-  "client_documentation": "https://googleapis.dev/python/datastore/latest",
-  "issue_tracker": "https://issuetracker.google.com/savedsearches/559768",
-  "release_level": "ga",
-  "language": "python",
-  "library_type": "GAPIC_COMBO",
-  "repo": "googleapis/python-datastore",
-  "distribution_name": "google-cloud-datastore",
-  "api_id": "datastore.googleapis.com"
+    "name": "datastore",
+    "name_pretty": "Google Cloud Datastore",
+    "product_documentation": "https://cloud.google.com/datastore",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/datastore/latest",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559768",
+    "release_level": "ga",
+    "language": "python",
+    "library_type": "GAPIC_COMBO",
+    "repo": "googleapis/python-datastore",
+    "distribution_name": "google-cloud-datastore",
+    "api_id": "datastore.googleapis.com"
 }


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.