### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "datastore",
     "name_pretty": "Google Cloud Datastore",
     "product_documentation": "https://cloud.google.com/datastore",
-    "client_documentation": "https://googleapis.dev/python/datastore/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/datastore/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559768",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ all other queries.
    :target: https://pypi.org/project/google-cloud-datastore/
 .. _Google Cloud Datastore API: https://cloud.google.com/datastore/docs
 .. _Product Documentation:  https://cloud.google.com/datastore/docs
-.. _Client Library Documentation: https://googleapis.dev/python/datastore/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/datastore/latest
 
 Quick Start
 -----------


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.