### PR TITLE
fix(deps): move libcst to extras

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -20,10 +20,10 @@ If you previously were using modules or functions under the namespace
 To assist with this, we have included some helpful scripts to make some of the code
 modifications required to use 2.0.0.
 
-* Install the library
+* Install the library with `libcst`.
 
 ```py
-python3 -m pip install google-cloud-datastore
+python3 -m pip install google-cloud-datastore[libcst]
 ```
 
 * The scripts `fixup_datastore_v1_keywords.py` and `fixup_datastore_admin_v1_keywords.py` 

--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,8 @@ dependencies = [
     # https://github.com/googleapis/google-cloud-python/issues/10566
     "google-cloud-core >= 1.4.0, <3.0.0dev",
     "proto-plus >= 1.4.0",
-    "libcst >= 0.2.5",
 ]
-extras = {}
+extras = {"libcst >= 0.2.5"}
 
 
 # Setup boilerplate below this line.

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ dependencies = [
     "google-cloud-core >= 1.4.0, <3.0.0dev",
     "proto-plus >= 1.4.0",
 ]
-extras = {"libcst >= 0.2.5"}
+extras = {"libcst": "libcst >= 0.2.5"}
 
 
 # Setup boilerplate below this line.


### PR DESCRIPTION
Move `libcst` to extras. `libcst` is only needed to run the fixup script.
