### PR TITLE
chore(revert): revert add api for IN/NOT_IN/NOT_EQUAL operators

### DIFF
--- a/google/cloud/datastore/query.py
+++ b/google/cloud/datastore/query.py
@@ -86,9 +86,6 @@ class Query(object):
         "<": query_pb2.PropertyFilter.Operator.LESS_THAN,
         ">": query_pb2.PropertyFilter.Operator.GREATER_THAN,
         "=": query_pb2.PropertyFilter.Operator.EQUAL,
-        "!=": query_pb2.PropertyFilter.Operator.NOT_EQUAL,
-        "IN": query_pb2.PropertyFilter.Operator.IN,
-        "NOT_IN": query_pb2.PropertyFilter.Operator.NOT_IN,
     }
     """Mapping of operator strings and their protobuf equivalents."""
 
@@ -218,7 +215,7 @@ class Query(object):
 
         where property is a property stored on the entity in the datastore
         and operator is one of ``OPERATORS``
-        (ie, ``=``, ``<``, ``<=``, ``>``, ``>=``, ``!=``, ``IN``, ``NOT_IN``):
+        (ie, ``=``, ``<``, ``<=``, ``>``, ``>=``):
 
         .. testsetup:: query-filter
 
@@ -238,7 +235,7 @@ class Query(object):
         :param property_name: A property name.
 
         :type operator: str
-        :param operator: One of ``=``, ``<``, ``<=``, ``>``, ``>=``, ``!=``, ``IN``, ``NOT_IN``.
+        :param operator: One of ``=``, ``<``, ``<=``, ``>``, ``>=``.
 
         :type value: :class:`int`, :class:`str`, :class:`bool`,
                      :class:`float`, :class:`NoneType`,
@@ -255,7 +252,7 @@ class Query(object):
         """
         if self.OPERATORS.get(operator) is None:
             error_message = 'Invalid expression: "%s"' % (operator,)
-            choices_message = "Please use one of: =, <, <=, >, >=, !=, IN, NOT_IN."
+            choices_message = "Please use one of: =, <, <=, >, >=."
             raise ValueError(error_message, choices_message)
 
         if property_name == "__key__" and not isinstance(value, Key):
@@ -296,7 +293,7 @@ class Query(object):
         :param key: The key to filter on.
 
         :type operator: str
-        :param operator: (Optional) One of ``=``, ``<``, ``<=``, ``>``, ``>=``, ``!=``, ``IN``, ``NOT_IN``.
+        :param operator: (Optional) One of ``=``, ``<``, ``<=``, ``>``, ``>=``.
                          Defaults to ``=``.
         """
         self.add_filter("__key__", operator, key)

--- a/google/cloud/datastore_v1/types/query.py
+++ b/google/cloud/datastore_v1/types/query.py
@@ -260,10 +260,7 @@ class PropertyFilter(proto.Message):
         GREATER_THAN = 3
         GREATER_THAN_OR_EQUAL = 4
         EQUAL = 5
-        IN = 6
-        NOT_EQUAL = 9
         HAS_ANCESTOR = 11
-        NOT_IN = 13
 
     property = proto.Field(proto.MESSAGE, number=1, message="PropertyReference",)
     op = proto.Field(proto.ENUM, number=2, enum=Operator,)

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -175,18 +175,12 @@ def test_query_add_filter_w_all_operators():
     query.add_filter("lt_prop", "<", "val3")
     query.add_filter("gt_prop", ">", "val4")
     query.add_filter("eq_prop", "=", "val5")
-    query.add_filter("in_prop", "IN", ["val6"])
-    query.add_filter("neq_prop", "!=", "val9")
-    query.add_filter("not_in_prop", "NOT_IN", ["val13"])
-    assert len(query.filters) == 8
+    assert len(query.filters) == 5
     assert query.filters[0] == ("leq_prop", "<=", "val1")
     assert query.filters[1] == ("geq_prop", ">=", "val2")
     assert query.filters[2] == ("lt_prop", "<", "val3")
     assert query.filters[3] == ("gt_prop", ">", "val4")
     assert query.filters[4] == ("eq_prop", "=", "val5")
-    assert query.filters[5] == ("in_prop", "IN", ["val6"])
-    assert query.filters[6] == ("neq_prop", "!=", "val9")
-    assert query.filters[7] == ("not_in_prop", "NOT_IN", ["val13"])
 
 
 def test_query_add_filter_w_known_operator_and_entity():


### PR DESCRIPTION
Reverts googleapis/python-datastore#282

This change will be included in a future release.