### PR TITLE
chore: remove owlbot from required checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -19,7 +19,6 @@ branchProtectionRules:
     - 'Kokoro'
     - 'Kokoro system-3.8'
     - 'cla/google'
-    - 'OwlBot Post Processor'
     - 'docs'
     - 'docfx'
     - 'lint'


### PR DESCRIPTION
Removing owlbot from required, as it only needs to run when certain files are changed