### PR TITLE
build: treat warnings as errors

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -15,3 +15,5 @@ filterwarnings =
     ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning:google.api_core.datetime_helpers
     # Remove once https://github.com/grpc/grpc/issues/35086 is fixed
     ignore:There is no current event loop:DeprecationWarning:grpc.aio._channel
+    # Remove once a version of grpcio newer than 1.59.3 is released to PyPI
+    ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning:grpc._channel

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,5 @@ filterwarnings =
     ignore:Detected filter using positional arguments:UserWarning
     # Remove once https://github.com/grpc/grpc/issues/35086 is fixed
     ignore:There is no current event loop:DeprecationWarning:grpc.aio._channel
+    # Remove after support for Python 3.7 is dropped
+    ignore:After January 1, 2024, new releases of this library will drop support for Python 3.7:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,11 @@
+[pytest]
+filterwarnings =
+    # treat all warnings as errors
+    error
+    # Remove once https://github.com/protocolbuffers/protobuf/issues/12186 is fixed
+    ignore:.*custom tp_new.*in Python 3.14:DeprecationWarning
+    # Remove once https://github.com/googleapis/python-api-common-protos/pull/187/files is merged
+    ignore:.*pkg_resources.declare_namespace:DeprecationWarning
+    ignore:.*pkg_resources is deprecated as an API:DeprecationWarning
+    # Remove once https://github.com/googleapis/python-datastore/issues/504 is fixed
+    ignore:Detected filter using positional arguments:UserWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,7 @@ filterwarnings =
     error
     # Remove once https://github.com/protocolbuffers/protobuf/issues/12186 is fixed
     ignore:.*custom tp_new.*in Python 3.14:DeprecationWarning
-    # Remove once https://github.com/googleapis/python-api-common-protos/pull/187/files is merged
+    # Remove once Release PR https://github.com/googleapis/python-api-common-protos/pull/191 is merged
     ignore:.*pkg_resources.declare_namespace:DeprecationWarning
     ignore:.*pkg_resources is deprecated as an API:DeprecationWarning
     # Remove once https://github.com/googleapis/python-datastore/issues/504 is fixed

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,9 @@ filterwarnings =
     ignore:.*pkg_resources is deprecated as an API:DeprecationWarning
     # Remove once https://github.com/googleapis/python-datastore/issues/504 is fixed
     ignore:Detected filter using positional arguments:UserWarning
+    # Remove once release PR https://github.com/googleapis/proto-plus-python/pull/391 is merged
+    ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning:proto.datetime_helpers
+    # Remove once release PR https://github.com/googleapis/python-api-core/pull/555 is merged
+    ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning:google.api_core.datetime_helpers
+    # Remove once https://github.com/grpc/grpc/issues/35086 is fixed
+    ignore:There is no current event loop:DeprecationWarning:grpc.aio._channel

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,16 +4,7 @@ filterwarnings =
     error
     # Remove once https://github.com/protocolbuffers/protobuf/issues/12186 is fixed
     ignore:.*custom tp_new.*in Python 3.14:DeprecationWarning
-    # Remove once Release PR https://github.com/googleapis/python-api-common-protos/pull/191 is merged
-    ignore:.*pkg_resources.declare_namespace:DeprecationWarning
-    ignore:.*pkg_resources is deprecated as an API:DeprecationWarning
     # Remove once https://github.com/googleapis/python-datastore/issues/504 is fixed
     ignore:Detected filter using positional arguments:UserWarning
-    # Remove once release PR https://github.com/googleapis/proto-plus-python/pull/391 is merged
-    ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning:proto.datetime_helpers
-    # Remove once release PR https://github.com/googleapis/python-api-core/pull/555 is merged
-    ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning:google.api_core.datetime_helpers
     # Remove once https://github.com/grpc/grpc/issues/35086 is fixed
     ignore:There is no current event loop:DeprecationWarning:grpc.aio._channel
-    # Remove once a version of grpcio newer than 1.59.3 is released to PyPI
-    ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning:grpc._channel

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1245,14 +1245,14 @@ def _assert_reserve_ids_warning(warned):
 
 @pytest.mark.parametrize("database_id", [None, "somedb"])
 def test_client_reserve_ids_w_partial_key(database_id):
-    import warnings
-
     num_ids = 2
     incomplete_key = _Key(_Key.kind, None)
     creds = _make_credentials()
     client = _make_client(credentials=creds, database=database_id)
     with pytest.raises(ValueError):
-        with warnings.catch_warnings(record=True) as warned:
+        with pytest.warns(
+            DeprecationWarning, match="Client.reserve_ids is deprecated"
+        ) as warned:
             client.reserve_ids(incomplete_key, num_ids)
 
     _assert_reserve_ids_warning(warned)
@@ -1260,14 +1260,14 @@ def test_client_reserve_ids_w_partial_key(database_id):
 
 @pytest.mark.parametrize("database_id", [None, "somedb"])
 def test_client_reserve_ids_w_wrong_num_ids(database_id):
-    import warnings
-
     num_ids = "2"
     complete_key = _Key(database=database_id)
     creds = _make_credentials()
     client = _make_client(credentials=creds, database=database_id)
     with pytest.raises(ValueError):
-        with warnings.catch_warnings(record=True) as warned:
+        with pytest.warns(
+            DeprecationWarning, match="Client.reserve_ids is deprecated"
+        ) as warned:
             client.reserve_ids(complete_key, num_ids)
 
     _assert_reserve_ids_warning(warned)
@@ -1275,14 +1275,14 @@ def test_client_reserve_ids_w_wrong_num_ids(database_id):
 
 @pytest.mark.parametrize("database_id", [None, "somedb"])
 def test_client_reserve_ids_w_non_numeric_key_name(database_id):
-    import warnings
-
     num_ids = 2
     complete_key = _Key(_Key.kind, "batman", database=database_id)
     creds = _make_credentials()
     client = _make_client(credentials=creds, database=database_id)
     with pytest.raises(ValueError):
-        with warnings.catch_warnings(record=True) as warned:
+        with pytest.warns(
+            DeprecationWarning, match="Client.reserve_ids is deprecated"
+        ) as warned:
             client.reserve_ids(complete_key, num_ids)
 
     _assert_reserve_ids_warning(warned)
@@ -1290,8 +1290,6 @@ def test_client_reserve_ids_w_non_numeric_key_name(database_id):
 
 @pytest.mark.parametrize("database_id", [None, "somedb"])
 def test_client_reserve_ids_w_completed_key(database_id):
-    import warnings
-
     num_ids = 2
     creds = _make_credentials()
     client = _make_client(credentials=creds, _use_grpc=False, database=database_id)
@@ -1301,7 +1299,9 @@ def test_client_reserve_ids_w_completed_key(database_id):
     client._datastore_api_internal = ds_api
     assert not complete_key.is_partial
 
-    with warnings.catch_warnings(record=True) as warned:
+    with pytest.warns(
+        DeprecationWarning, match="Client.reserve_ids is deprecated"
+    ) as warned:
         client.reserve_ids(complete_key, num_ids)
 
     reserved_keys = (
@@ -1317,8 +1317,6 @@ def test_client_reserve_ids_w_completed_key(database_id):
 
 @pytest.mark.parametrize("database_id", [None, "somedb"])
 def test_client_reserve_ids_w_completed_key_w_retry_w_timeout(database_id):
-    import warnings
-
     num_ids = 2
     retry = mock.Mock()
     timeout = 100000
@@ -1331,7 +1329,9 @@ def test_client_reserve_ids_w_completed_key_w_retry_w_timeout(database_id):
     ds_api = mock.Mock(reserve_ids=reserve_ids, spec=["reserve_ids"])
     client._datastore_api_internal = ds_api
 
-    with warnings.catch_warnings(record=True) as warned:
+    with pytest.warns(
+        DeprecationWarning, match="Client.reserve_ids is deprecated"
+    ) as warned:
         client.reserve_ids(complete_key, num_ids, retry=retry, timeout=timeout)
 
     reserved_keys = (
@@ -1351,8 +1351,6 @@ def test_client_reserve_ids_w_completed_key_w_retry_w_timeout(database_id):
 
 @pytest.mark.parametrize("database_id", [None, "somedb"])
 def test_client_reserve_ids_w_completed_key_w_ancestor(database_id):
-    import warnings
-
     num_ids = 2
     creds = _make_credentials()
     client = _make_client(credentials=creds, _use_grpc=False, database=database_id)
@@ -1362,7 +1360,9 @@ def test_client_reserve_ids_w_completed_key_w_ancestor(database_id):
     client._datastore_api_internal = ds_api
     assert not complete_key.is_partial
 
-    with warnings.catch_warnings(record=True) as warned:
+    with pytest.warns(
+        DeprecationWarning, match="Client.reserve_ids is deprecated"
+    ) as warned:
         client.reserve_ids(complete_key, num_ids)
 
     reserved_keys = (

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -713,7 +713,7 @@ def test_client_get_multi_hit_w_read_time(database_id):
     from google.cloud.datastore_v1.types import datastore as datastore_pb2
     from google.protobuf.timestamp_pb2 import Timestamp
 
-    read_time = datetime.utcfromtimestamp(1641058200.123456)
+    read_time = datetime.fromtimestamp(1641058200.123456)
     read_time_pb = Timestamp(seconds=1641058200, nanos=123456000)
     kind = "Kind"
     id_ = 1234

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -579,7 +579,7 @@ def test__get_read_options_w_default_wo_txn_w_read_time():
     from google.cloud.datastore_v1.types import datastore as datastore_pb2
     from google.protobuf.timestamp_pb2 import Timestamp
 
-    read_time = datetime.utcfromtimestamp(1641058200.123456)
+    read_time = datetime.fromtimestamp(1641058200.123456)
     read_time_pb = Timestamp(seconds=1641058200, nanos=123456000)
     read_options = get_read_options(False, None, read_time)
     expected = datastore_pb2.ReadOptions(read_time=read_time_pb)

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -956,7 +956,7 @@ def test_iterator__next_page_in_transaction(database_id):
 
 @pytest.mark.parametrize("database_id", [None, "somedb"])
 def test_iterator__next_page_w_read_time(database_id):
-    read_time = datetime.datetime.utcfromtimestamp(1641058200.123456)
+    read_time = datetime.datetime.fromtimestamp(1641058200.123456)
     _next_page_helper(read_time=read_time, database=database_id)
 
 

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -56,7 +56,7 @@ def test_transaction_constructor_w_read_time(database_id):
 
     project = "PROJECT"
     id_ = 850302
-    read_time = datetime.utcfromtimestamp(1641058200.123456)
+    read_time = datetime.fromtimestamp(1641058200.123456)
     ds_api = _make_datastore_api(xact=id_)
     client = _Client(project, datastore_api=ds_api, database=database_id)
     options = _make_options(read_only=True, read_time=read_time)
@@ -73,7 +73,7 @@ def test_transaction_constructor_read_write_w_read_time(database_id):
 
     project = "PROJECT"
     id_ = 850302
-    read_time = datetime.utcfromtimestamp(1641058200.123456)
+    read_time = datetime.fromtimestamp(1641058200.123456)
     ds_api = _make_datastore_api(xact=id_)
     client = _Client(project, datastore_api=ds_api, database=database_id)
 
@@ -178,7 +178,7 @@ def test_transaction_begin_w_read_time(database_id):
 
     project = "PROJECT"
     id_ = 889
-    read_time = datetime.utcfromtimestamp(1641058200.123456)
+    read_time = datetime.fromtimestamp(1641058200.123456)
     ds_api = _make_datastore_api(xact_id=id_)
     client = _Client(project, datastore_api=ds_api, database=database_id)
     xact = _make_transaction(client, read_only=True, read_time=read_time)


### PR DESCRIPTION
This PR adds a `pytest.ini` to treat warnings as errors.

I also included some simple fixes. Let me know if these should be pulled out into separate PRs with corresponding issues created.