### PR TITLE
fix: Using end_cursor instead of skipped_cursor in Iterator to fix rare bug.

### DIFF
--- a/google/cloud/datastore/query.py
+++ b/google/cloud/datastore/query.py
@@ -825,7 +825,7 @@ class Iterator(page_iterator.Iterator):
             old_query_pb = query_pb
             query_pb = query_pb2.Query()
             query_pb._pb.CopyFrom(old_query_pb._pb)  # copy for testability
-            query_pb.start_cursor = response_pb.batch.skipped_cursor
+            query_pb.start_cursor = response_pb.batch.end_cursor
             query_pb.offset -= response_pb.batch.skipped_results
 
             request = {

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1057,9 +1057,7 @@ def test_iterator__next_page_w_skipped_lt_offset(skipped_cursor_1, database_id):
     read_options = datastore_pb2.ReadOptions()
 
     query_1 = query_pb2.Query(offset=offset)
-    query_2 = query_pb2.Query(
-        start_cursor=end_cursor_1, offset=(offset - skipped_1)
-    )
+    query_2 = query_pb2.Query(start_cursor=end_cursor_1, offset=(offset - skipped_1))
     expected_calls = []
     for query in [query_1, query_2]:
         expected_request = {

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1019,7 +1019,8 @@ def test_iterator__next_page_no_more(database_id):
 
 
 @pytest.mark.parametrize("database_id", [None, "somedb"])
-def test_iterator__next_page_w_skipped_lt_offset(database_id):
+@pytest.mark.parametrize("skipped_cursor_1", [b"DEADBEEF", b""])
+def test_iterator__next_page_w_skipped_lt_offset(skipped_cursor_1, database_id):
     from google.api_core import page_iterator
     from google.cloud.datastore_v1.types import datastore as datastore_pb2
     from google.cloud.datastore_v1.types import entity as entity_pb2
@@ -1028,16 +1029,17 @@ def test_iterator__next_page_w_skipped_lt_offset(database_id):
 
     project = "prujekt"
     skipped_1 = 100
-    skipped_cursor_1 = b"DEADBEEF"
+    end_cursor_1 = b"DEADBEEF"
     skipped_2 = 50
-    skipped_cursor_2 = b"FACEDACE"
+    end_cursor_2 = b"FACEDACE"
 
     more_enum = query_pb2.QueryResultBatch.MoreResultsType.NOT_FINISHED
 
     result_1 = _make_query_response([], b"", more_enum, skipped_1)
     result_1.batch.skipped_cursor = skipped_cursor_1
+    result_1.batch.end_cursor = end_cursor_1
     result_2 = _make_query_response([], b"", more_enum, skipped_2)
-    result_2.batch.skipped_cursor = skipped_cursor_2
+    result_2.batch.end_cursor = end_cursor_2
 
     ds_api = _make_datastore_api(result_1, result_2)
     client = _Client(project, datastore_api=ds_api, database=database_id)
@@ -1056,7 +1058,7 @@ def test_iterator__next_page_w_skipped_lt_offset(database_id):
 
     query_1 = query_pb2.Query(offset=offset)
     query_2 = query_pb2.Query(
-        start_cursor=skipped_cursor_1, offset=(offset - skipped_1)
+        start_cursor=end_cursor_1, offset=(offset - skipped_1)
     )
     expected_calls = []
     for query in [query_1, query_2]:


### PR DESCRIPTION
Using `end_cursor` instead of `skipped_cursor` to fix #547. There are some rare edge cases where `skipped_cursor` returns an empty string with still more things to skip. Switching to `end_cursor` resolves this issue. Also does not reintroduce the bug that was fixed in #18, as in those cases, `skipped_cursor` and `end_cursor` are the same.

Integration tests will be coming soon, maybe in a future PR, as making a dataset that consistently replicates this issue is still under investigation.
