### PR TITLE
chore: Add mypy ignore for union-attr error

### DIFF
--- a/google/cloud/datastore_v1/services/datastore/async_client.py
+++ b/google/cloud/datastore_v1/services/datastore/async_client.py
@@ -1319,7 +1319,7 @@ class DatastoreAsyncClient:
         # Certain fields should be provided within the metadata header;
         # add these here.
         metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),
+            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),  # type: ignore[union-attr] # TODO: https://github.com/googleapis/python-datastore/issues/649 - Fix type hint issue
         )
 
         # Validate the universe domain.
@@ -1374,7 +1374,7 @@ class DatastoreAsyncClient:
         # Certain fields should be provided within the metadata header;
         # add these here.
         metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),
+            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),  # type: ignore[union-attr] # TODO: https://github.com/googleapis/python-datastore/issues/649 - Fix type hint issue
         )
 
         # Validate the universe domain.
@@ -1433,7 +1433,7 @@ class DatastoreAsyncClient:
         # Certain fields should be provided within the metadata header;
         # add these here.
         metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),
+            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),  # type: ignore[union-attr] # TODO: https://github.com/googleapis/python-datastore/issues/649 - Fix type hint issue
         )
 
         # Validate the universe domain.
@@ -1488,7 +1488,7 @@ class DatastoreAsyncClient:
         # Certain fields should be provided within the metadata header;
         # add these here.
         metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),
+            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),  # type: ignore[union-attr] # TODO: https://github.com/googleapis/python-datastore/issues/649 - Fix type hint issue
         )
 
         # Validate the universe domain.

--- a/google/cloud/datastore_v1/services/datastore/client.py
+++ b/google/cloud/datastore_v1/services/datastore/client.py
@@ -1719,7 +1719,7 @@ class DatastoreClient(metaclass=DatastoreClientMeta):
         # Certain fields should be provided within the metadata header;
         # add these here.
         metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),
+            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),  # type: ignore[union-attr] # TODO: https://github.com/googleapis/python-datastore/issues/649 - Fix type hint issue
         )
 
         # Validate the universe domain.
@@ -1778,7 +1778,7 @@ class DatastoreClient(metaclass=DatastoreClientMeta):
         # Certain fields should be provided within the metadata header;
         # add these here.
         metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),
+            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),  # type: ignore[union-attr] # TODO: https://github.com/googleapis/python-datastore/issues/649 - Fix type hint issue
         )
 
         # Validate the universe domain.
@@ -1841,7 +1841,7 @@ class DatastoreClient(metaclass=DatastoreClientMeta):
         # Certain fields should be provided within the metadata header;
         # add these here.
         metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),
+            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),  # type: ignore[union-attr] # TODO: https://github.com/googleapis/python-datastore/issues/649 - Fix type hint issue
         )
 
         # Validate the universe domain.
@@ -1896,7 +1896,7 @@ class DatastoreClient(metaclass=DatastoreClientMeta):
         # Certain fields should be provided within the metadata header;
         # add these here.
         metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),
+            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),  # type: ignore[union-attr] # TODO: https://github.com/googleapis/python-datastore/issues/649 - Fix type hint issue
         )
 
         # Validate the universe domain.


### PR DESCRIPTION
This PR adds `# type: ignore[union-attr]` to lines in `datastore_v1/services/datastore/client.py` and `datastore_v1/services/datastore/async_client.py` that were causing mypy errors due to potential `None` values.

This is a temporary measure to unblock other work. The underlying type hint issue is tracked in https://github.com/googleapis/google-cloud-python/issues/15337.
