### PR TITLE
chore: librarian release pull request: 20251113T155623Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:ce48ed695c727f7e13efd1fd68f466a55a0d772c87b69158720cec39965bc8b2
 libraries:
   - id: google-cloud-datastore
-    version: 2.21.0
+    version: 2.22.0
     last_generated_commit: 659ea6e98acc7d58661ce2aa7b4cf76a7ef3fd42
     apis:
       - path: google/datastore/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/google-cloud-datastore/#history
 
+## [2.22.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-datastore-v2.21.0...google-cloud-datastore-v2.22.0) (2025-11-13)
+
+
+### Bug Fixes
+
+* remove setup.cfg configuration for creating universal wheels (#601) ([df729015149bd69e9d6dbced260d97c8eed77d4f](https://github.com/googleapis/google-cloud-python/commit/df729015149bd69e9d6dbced260d97c8eed77d4f))
+
 ## [2.21.0](https://github.com/googleapis/python-datastore/compare/v2.20.2...v2.21.0) (2025-04-10)
 
 

--- a/google/cloud/datastore/gapic_version.py
+++ b/google/cloud/datastore/gapic_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.21.0"  # {x-release-please-version}
+__version__ = "2.22.0"  # {x-release-please-version}

--- a/google/cloud/datastore/version.py
+++ b/google/cloud/datastore/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.21.0"
+__version__ = "2.22.0"

--- a/google/cloud/datastore_admin/gapic_version.py
+++ b/google/cloud/datastore_admin/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.21.0"  # {x-release-please-version}
+__version__ = "2.22.0"  # {x-release-please-version}

--- a/google/cloud/datastore_admin_v1/gapic_version.py
+++ b/google/cloud/datastore_admin_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.21.0"  # {x-release-please-version}
+__version__ = "2.22.0"  # {x-release-please-version}

--- a/google/cloud/datastore_v1/gapic_version.py
+++ b/google/cloud/datastore_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.21.0"  # {x-release-please-version}
+__version__ = "2.22.0"  # {x-release-please-version}


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:ce48ed695c727f7e13efd1fd68f466a55a0d772c87b69158720cec39965bc8b2
<details><summary>google-cloud-datastore: 2.22.0</summary>

## [2.22.0](https://github.com/googleapis/python-datastore/compare/v2.21.0...v2.22.0) (2025-11-13)

### Bug Fixes

* remove setup.cfg configuration for creating universal wheels (#601) ([df729015](https://github.com/googleapis/python-datastore/commit/df729015))

</details>