### PR TITLE
chore(tests): update kokoro continuous test config

### DIFF
--- a/.kokoro/continuous/continuous.cfg
+++ b/.kokoro/continuous/continuous.cfg
@@ -1,1 +1,12 @@
 # Format: //devtools/kokoro/config/proto/build.proto
+
+# Disable system tests.
+env_vars: {
+    key: "RUN_SYSTEM_TESTS"
+    value: "false"
+}
+
+env_vars: {
+    key: "NOX_SESSION"
+    value: "blacken doctests format"
+}


### PR DESCRIPTION
The continuous kokoro test should use the [same configuration as the pre-submit](https://github.com/googleapis/python-datastore/blob/main/.kokoro/presubmit/presubmit.cfg)
