### PR TITLE
chore: librarian release pull request: 20251216T133331Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:b8058df4c45e9a6e07f6b4d65b458d0d059241dd34c814f151c8bf6b89211209
 libraries:
   - id: google-cloud-datastore
-    version: 2.22.0
+    version: 2.23.0
     last_generated_commit: 659ea6e98acc7d58661ce2aa7b4cf76a7ef3fd42
     apis:
       - path: google/datastore/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/google-cloud-datastore/#history
 
+## [2.23.0](https://github.com/googleapis/python-datastore/compare/v2.22.0...v2.23.0) (2025-12-16)
+
+
+### Features
+
+* support mTLS certificates when available (#658) ([85c023287daebb0d5c1a009e2beaccf0c6ea75eb](https://github.com/googleapis/python-datastore/commit/85c023287daebb0d5c1a009e2beaccf0c6ea75eb))
+
 ## [2.22.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-datastore-v2.21.0...google-cloud-datastore-v2.22.0) (2025-12-12)
 
 

--- a/google/cloud/datastore/gapic_version.py
+++ b/google/cloud/datastore/gapic_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.22.0"  # {x-release-please-version}
+__version__ = "2.23.0"  # {x-release-please-version}

--- a/google/cloud/datastore/version.py
+++ b/google/cloud/datastore/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.22.0"
+__version__ = "2.23.0"

--- a/google/cloud/datastore_admin/gapic_version.py
+++ b/google/cloud/datastore_admin/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.22.0"  # {x-release-please-version}
+__version__ = "2.23.0"  # {x-release-please-version}

--- a/google/cloud/datastore_admin_v1/gapic_version.py
+++ b/google/cloud/datastore_admin_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.22.0"  # {x-release-please-version}
+__version__ = "2.23.0"  # {x-release-please-version}

--- a/google/cloud/datastore_v1/gapic_version.py
+++ b/google/cloud/datastore_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.22.0"  # {x-release-please-version}
+__version__ = "2.23.0"  # {x-release-please-version}


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:b8058df4c45e9a6e07f6b4d65b458d0d059241dd34c814f151c8bf6b89211209
<details><summary>google-cloud-datastore: 2.23.0</summary>

## [2.23.0](https://github.com/googleapis/python-datastore/compare/v2.22.0...v2.23.0) (2025-12-16)

### Features

* support mTLS certificates when available (#658) ([85c02328](https://github.com/googleapis/python-datastore/commit/85c02328))

</details>